### PR TITLE
Fix: extract tools property from return value of '/servers/{name}/tools'

### DIFF
--- a/src/mcpd_sdk/mcpd_client.py
+++ b/src/mcpd_sdk/mcpd_client.py
@@ -73,7 +73,8 @@ class McpdClient:
             url = f"{self.endpoint}/api/v1/servers/{server_name}/tools"
             response = self.session.get(url, timeout=5)
             response.raise_for_status()
-            return response.json()
+            data = response.json()
+            return data.get("tools", [])
         except requests.exceptions.RequestException as e:
             raise McpdError(f"Error listing tool definitions for server '{server_name}'") from e
 


### PR DESCRIPTION
Response now follows new schema, so we need to get the `tools` property.

e.g.

```json
{
  "$schema": "http://localhost:8090/schemas/Tools.json",
  "tools": [
    { 
      ... 
    }
  ]
}
```