### PR TITLE
Add methods to query health endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ client = McpdClient(api_endpoint="http://localhost:8090", api_key="optional-key"
 
 * `client.call.<server_name>.<tool_name>(**kwargs)` - The primary way to dynamically call any tool using keyword arguments.
 
+* `client.server_health() -> dict[str, dict]` - Returns a dictionary mapping each server name to the health information of that server.
+
+* `client.server_health(server_name: str) -> dict` - Returns the health information for only the specified server.
+
+* `client.is_server_healthy(server_name: str) -> bool` - Checks if the specified server is healthy and can handle requests.
+
 ## Error Handling
 
 All SDK-level errors, including HTTP and connection errors, will raise a `McpdError` exception.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This SDK provides high-level and dynamic access to those tools, making it easy t
 - Retrieve tool definitions and schemas for one or all servers
 - Dynamically invoke any tool using a clean, attribute-based syntax
 - Generate self-contained, deepcopy-safe tool functions for frameworks like [any-agent](https://github.com/mozilla-ai/any-agent)
-- Minimal dependencies (`requests` only)
+- Minimal dependencies (`requests` and `cachetools` only)
 
 ## Installation in your project
 
@@ -121,7 +121,8 @@ from mcpd import McpdClient
 
 # Initialize the client with your mcpd API endpoint.
 # api_key is optional and sends an 'MCPD-API-KEY' header.
-client = McpdClient(api_endpoint="http://localhost:8090", api_key="optional-key")
+# server_health_cache_ttl is optional and sets the time in seconds to cache a server health response.
+client = McpdClient(api_endpoint="http://localhost:8090", api_key="optional-key", server_health_cache_ttl=10)
 ```
 
 ### Core Methods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 license = {text = "Apache-2.0"}
 requires-python = ">=3.11"
 dependencies = [
+    "cachetools>=6.2.0",
     "requests>=2.32.4",
 ]
 

--- a/src/mcpd/__init__.py
+++ b/src/mcpd/__init__.py
@@ -17,19 +17,22 @@ from .exceptions import (
     ConnectionError,
     McpdError,
     ServerNotFoundError,
+    ServerUnhealthyError,
     TimeoutError,
     ToolExecutionError,
     ToolNotFoundError,
     ValidationError,
 )
-from .mcpd_client import McpdClient
+from .mcpd_client import HealthStatus, McpdClient
 
 __all__ = [
     "McpdClient",
+    "HealthStatus",
     "McpdError",
     "AuthenticationError",
     "ConnectionError",
     "ServerNotFoundError",
+    "ServerUnhealthyError",
     "TimeoutError",
     "ToolExecutionError",
     "ToolNotFoundError",

--- a/src/mcpd/exceptions.py
+++ b/src/mcpd/exceptions.py
@@ -132,6 +132,41 @@ class ServerNotFoundError(McpdError):
         self.server_name = server_name
 
 
+class ServerUnhealthyError(McpdError):
+    """Raised when a specified MCP server is not healthy.
+
+    This indicates that the server exists but is currently unhealthy:
+    - The server is down or unreachable
+    - Timeout occurred while checking health
+    - No health data is available for the server
+
+    Attributes:
+        server_name: The name of the server that is unhealthy.
+        health_status: Details about the server's health status (if available).
+                      Can be one of timeout, unreachable, unknown.
+
+    Example:
+        >>> try:
+        >>>     tools = client.tools("unhealthy_server")
+        >>> except ServerUnhealthyError as e:
+        >>>     print(f"Server '{e.server_name}' is unhealthy")
+        >>>     if e.health_status:
+        >>>         print(f"Health details: {e.health_status}")
+    """
+
+    def __init__(self, message: str, server_name: str, health_status: str):
+        """Initialize ServerUnhealthyError.
+
+        Args:
+            message: The error message.
+            server_name: The name of the server that is unhealthy.
+            health_status: Details about the server's health status.
+        """
+        super().__init__(message)
+        self.server_name = server_name
+        self.health_status = health_status
+
+
 class ToolNotFoundError(McpdError):
     """Raised when a specified tool doesn't exist on a server.
 

--- a/src/mcpd/mcpd_client.py
+++ b/src/mcpd/mcpd_client.py
@@ -653,6 +653,13 @@ class McpdClient:
             >>> print(health_info["status"])
             ok
             >>>
+            >>> # Check if a server failure is temporary (useful for retry logic)
+            >>> health_info = client.server_health(server_name="problematic_server")
+            >>> if HealthStatus.is_transient(health_info["status"]):
+            ...     print("Temporary issue, will retry")
+            ... else:
+            ...     print("Persistent problem, requires intervention")
+            >>>
             >>> # Get health for all servers
             >>> all_health = client.server_health()
             >>> for server, health in all_health.items():

--- a/src/mcpd/mcpd_client.py
+++ b/src/mcpd/mcpd_client.py
@@ -745,9 +745,13 @@ class McpdClient:
             server_name: The name of the MCP server to check.
 
         Returns:
-            True if the server is healthy, False otherwise.
-            Returns False if the server doesn't exist, is unreachable or unhealthy, or if any
-            other error occurs during the check.
+            True if the server is healthy, False if the server is unhealthy or doesn't exist.
+
+        Raises:
+            ConnectionError: If unable to connect to the mcpd daemon.
+            TimeoutError: If the health check request times out.
+            AuthenticationError: If API key authentication fails.
+            McpdError: For other daemon errors that prevent checking health status.
 
         Example:
             >>> client = McpdClient(api_endpoint="http://localhost:8090")
@@ -761,7 +765,8 @@ class McpdClient:
         try:
             self._raise_for_server_health(server_name)
             return True
-        except McpdError:
+        except (ServerUnhealthyError, ServerNotFoundError):
+            # These specific exceptions represent servers that are unhealthy one way or another
             return False
 
     def clear_server_health_cache(self, server_name: str | None = None) -> None:

--- a/tests/unit/test_mcpd_client.py
+++ b/tests/unit/test_mcpd_client.py
@@ -17,6 +17,15 @@ class TestHealthStatus:
 
     def test_is_healthy(self):
         assert HealthStatus.is_healthy(HealthStatus.OK.value)
+        assert not HealthStatus.is_healthy(HealthStatus.TIMEOUT.value)
+        assert not HealthStatus.is_healthy(HealthStatus.UNREACHABLE.value)
+        assert not HealthStatus.is_healthy(HealthStatus.UNKNOWN.value)
+
+    def test_is_transient(self):
+        assert HealthStatus.is_transient(HealthStatus.TIMEOUT.value)
+        assert HealthStatus.is_transient(HealthStatus.UNKNOWN.value)
+        assert not HealthStatus.is_transient(HealthStatus.OK.value)
+        assert not HealthStatus.is_transient(HealthStatus.UNREACHABLE.value)
 
 
 class TestMcpdClient:

--- a/tests/unit/test_mcpd_client.py
+++ b/tests/unit/test_mcpd_client.py
@@ -229,6 +229,13 @@ class TestMcpdClient:
 
     @patch.object(McpdClient, "server_health")
     def test_is_healthy_error(self, mock_health, client):
+        # Test that ServerUnhealthyError returns False
+        mock_health.side_effect = ServerUnhealthyError(
+            "Server is unhealthy", server_name="test_server", health_status="unreachable"
+        )
+        result = client.is_server_healthy("test_server")
+        assert result is False
+
         # Test that ServerNotFoundError returns False
         mock_health.side_effect = ServerNotFoundError("Server not found", server_name="test_server")
         result = client.is_server_healthy("test_server")

--- a/tests/unit/test_mcpd_client.py
+++ b/tests/unit/test_mcpd_client.py
@@ -229,11 +229,15 @@ class TestMcpdClient:
 
     @patch.object(McpdClient, "server_health")
     def test_is_healthy_error(self, mock_health, client):
-        mock_health.side_effect = McpdError("Health check failed")
-
+        # Test that ServerNotFoundError returns False
+        mock_health.side_effect = ServerNotFoundError("Server not found", server_name="test_server")
         result = client.is_server_healthy("test_server")
-
         assert result is False
+
+        # Test that generic McpdError propagates
+        mock_health.side_effect = McpdError("Health check failed")
+        with pytest.raises(McpdError, match="Health check failed"):
+            client.is_server_healthy("test_server")
 
     def test_cacheable_exceptions(self):
         expected = {ServerNotFoundError, ServerUnhealthyError, AuthenticationError}

--- a/tests/unit/test_mcpd_client.py
+++ b/tests/unit/test_mcpd_client.py
@@ -230,6 +230,9 @@ class TestMcpdClient:
         expected = {ServerNotFoundError, ServerUnhealthyError, AuthenticationError}
         assert expected == set(McpdClient._CACHEABLE_EXCEPTIONS)
 
+    def test_server_health_cache_maxsize(self):
+        assert McpdClient._SERVER_HEALTH_CACHE_MAXSIZE == 100
+
     @patch.object(Session, "get")
     def test_server_health_cache(self, mock_get):
         client = McpdClient(api_endpoint="http://localhost:8090", server_health_cache_ttl=math.inf)
@@ -291,7 +294,7 @@ class TestMcpdClient:
 
         with pytest.raises(McpdError) as e:
             client.server_health("test_server")
-        
+
         assert not isinstance(e.value, client._CACHEABLE_EXCEPTIONS)
 
         mock_get.assert_called_once_with("http://localhost:8090/api/v1/health/servers/test_server", timeout=5)

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 2
 requires-python = ">=3.11"
 
 [[package]]
+name = "cachetools"
+version = "6.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/61/e4fad8155db4a04bfb4734c7c8ff0882f078f24294d42798b3568eb63bff/cachetools-6.2.0.tar.gz", hash = "sha256:38b328c0889450f05f5e120f56ab68c8abaf424e1275522b138ffc93253f7e32", size = 30988, upload-time = "2025-08-25T18:57:30.924Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/56/3124f61d37a7a4e7cc96afc5492c78ba0cb551151e530b54669ddd1436ef/cachetools-6.2.0-py3-none-any.whl", hash = "sha256:1c76a8960c0041fcc21097e357f882197c79da0dbff766e7317890a65d7d8ba6", size = 11276, upload-time = "2025-08-25T18:57:29.684Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2025.4.26"
 source = { registry = "https://pypi.org/simple" }
@@ -147,6 +156,7 @@ wheels = [
 name = "mcpd"
 source = { editable = "." }
 dependencies = [
+    { name = "cachetools" },
     { name = "requests" },
 ]
 
@@ -178,7 +188,10 @@ tests = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "requests", specifier = ">=2.32.4" }]
+requires-dist = [
+    { name = "cachetools", specifier = ">=6.2.0" },
+    { name = "requests", specifier = ">=2.32.4" },
+]
 
 [package.metadata.requires-dev]
 all = [


### PR DESCRIPTION
### What's Changed

1. Add methods to query MCP server health endpoints:
   * Health info of all servers
   * Health info of a single server
   * Is-healthy check
2. Cache server health responses using a TTL cache. 

### Notes

* Added the `cachetools` library for the caching mechanism (see https://github.com/tkem/cachetools/). The library is actively maintained, MIT-licensed and requires Python 3.9+, so it seems ok for use with the mcpd SDK.
* Let's address "health checks as pre-requisites for other calls" in a follow up PR, since this is already a lengthy one. 

Refs #11