### PR TITLE
Add health filtering to `agent_tools()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ client = McpdClient(api_endpoint="http://localhost:8090", api_key="optional-key"
 
 * `client.tools(server_name: str) -> list[dict]` - Returns the tool schema definitions for only the specified server.
 
-* `client.agent_tools(servers: list[str] | None = None, check_health: bool = True) -> list[Callable]` - Returns a list of self-contained, callable functions suitable for agentic frameworks. By default, filters to healthy servers only. Use `servers` to filter by server names, or `check_health=False` to include all servers regardless of health.
+* `client.agent_tools(servers: list[str] | None = None, *, check_health: bool = True) -> list[Callable]` - Returns a list of self-contained, callable functions suitable for agentic frameworks. By default, filters to healthy servers only. Use `servers` to filter by server names, or `check_health=False` to include all servers regardless of health.
 
 * `client.clear_agent_tools_cache()` - Clears cached generated callable functions that are created when calling agent_tools().
 

--- a/src/mcpd/mcpd_client.py
+++ b/src/mcpd/mcpd_client.py
@@ -394,7 +394,8 @@ class McpdClient:
                           Most users should leave this as True for best performance.
 
         Returns:
-            A list of callable functions, one for each tool from healthy servers.
+            A list of callable functions, one for each tool from healthy servers (if check_health=True, the default)
+            or all servers (if check_health=False).
             Each function has the following attributes:
             - __name__: The tool's qualified name (e.g., "time__get_current_time")
             - __doc__: The tool's description
@@ -406,7 +407,6 @@ class McpdClient:
             ConnectionError: If unable to connect to the mcpd daemon.
             TimeoutError: If requests to the daemon time out.
             AuthenticationError: If API key authentication fails.
-            ServerNotFoundError: If a server becomes unavailable during tool retrieval.
             McpdError: If unable to retrieve server health status (when check_health=True)
                       or retrieve tool definitions or generate functions.
 
@@ -482,6 +482,9 @@ class McpdClient:
             This method silently skips servers that don't exist or have
             unhealthy status (timeout, unreachable, unknown).
         """
+        if not server_names:
+            return []
+
         health_map = self.server_health()
 
         healthy_servers = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from unittest.mock import Mock
 
 import pytest
@@ -73,8 +74,8 @@ def tools_side_effect():
             mock_tools.side_effect = tools_side_effect(tools_map)
     """
 
-    def _create_side_effect(tools_map: dict[str, list[dict]]):
-        def side_effect(server_name=None):
+    def _create_side_effect(tools_map: dict[str, list[dict]]) -> Callable[[str | None], list[dict]]:
+        def side_effect(server_name: str | None = None) -> list[dict]:
             return tools_map.get(server_name, [])
 
         return side_effect


### PR DESCRIPTION
- Add `check_health` parameter to filter tools by server health status
- Defaults to `True` for best performance and JavaScript SDK parity
- Add `_get_healthy_servers()` helper method for batch health checking
- Silently skip unhealthy servers (timeout, unreachable, unknown)
- Add comprehensive unit tests for health filtering scenarios
- Update existing tests to mock server_health
- Update README with health filtering examples
- Maintains full backward compatibility via `check_health=False` option

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tools retrieval now filters to healthy servers by default; unhealthy servers are skipped. Option added to disable health filtering and to request specific servers when fetching tools.

* **Documentation**
  * Updated public API docs and examples to show the new parameters, default healthy-server behaviour and how to override it.

* **Tests**
  * Added and expanded tests and a fixture covering healthy/unhealthy servers, server selection, disabling checks and health-check error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->