### PR TITLE
Examples updates

### DIFF
--- a/examples/anyagent/.mcpd.toml
+++ b/examples/anyagent/.mcpd.toml
@@ -1,4 +1,4 @@
 [[servers]]
   name = "time"
-  package = "uvx::mcp-server-time@latest"
+  package = "uvx::mcp-server-time@2025.9.25"
   tools = ["get_current_time", "convert_time"]

--- a/examples/anyagent/README.md
+++ b/examples/anyagent/README.md
@@ -6,7 +6,7 @@ application code to call tools on those MCP servers.
 ## Requirements
 
 * [uv](https://docs.astral.sh/uv/getting-started/installation/)
-* [mcpd](https://github.com/mozilla-ai/mcpd-cli) built (`make build`) and installed (`sudo make install`)
+* [mcpd](https://mozilla-ai.github.io/mcpd/installation/) installed
 * `OPENAI_API_KEY` exported - this will be used by [any-agent](https://github.com/mozilla-ai/any-agent)
 
 ## Starting `mcpd`

--- a/examples/anyagent/pyproject.toml
+++ b/examples/anyagent/pyproject.toml
@@ -8,7 +8,7 @@ requires-python = ">=3.11"
 dependencies = [
     "any-agent[all]>=0.24.0",
     "requests>=2.32.4",
-    "mcpd>=0.0.1",
+    "mcpd>=0.0.2",
 ]
 
 [dependency-groups]

--- a/examples/anyagent/uv.lock
+++ b/examples/anyagent/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -244,11 +244,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "5.5.2"
+version = "6.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/44/ca1675be2a83aeee1886ab745b28cda92093066590233cc501890eb8417a/cachetools-6.2.2.tar.gz", hash = "sha256:8e6d266b25e539df852251cfd6f990b4bc3a141db73b939058d809ebd2590fc6", size = 31571, upload-time = "2025-11-13T17:42:51.465Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/46/eb6eca305c77a4489affe1c5d8f4cae82f285d9addd8de4ec084a7184221/cachetools-6.2.2-py3-none-any.whl", hash = "sha256:6c09c98183bf58560c97b2abfcedcbaf6a896a490f534b031b661d3723b45ace", size = 11503, upload-time = "2025-11-13T17:42:50.232Z" },
 ]
 
 [[package]]
@@ -563,7 +563,7 @@ tests = [
 [package.metadata]
 requires-dist = [
     { name = "any-agent", extras = ["all"], specifier = ">=0.24.0" },
-    { name = "mcpd", editable = "../../" },
+    { name = "mcpd", specifier = ">=0.0.2" },
     { name = "requests", specifier = ">=2.32.4" },
 ]
 
@@ -816,16 +816,16 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.40.3"
+version = "2.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "pyasn1-modules" },
     { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/9b/e92ef23b84fa10a64ce4831390b7a4c2e53c0132568d99d4ae61d04c8855/google_auth-2.40.3.tar.gz", hash = "sha256:500c3a29adedeb36ea9cf24b8d10858e152f2412e3ca37829b3fa18e33d63b77", size = 281029, upload-time = "2025-06-04T18:04:57.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/ef/66d14cf0e01b08d2d51ffc3c20410c4e134a1548fc246a6081eae585a4fe/google_auth-2.43.0.tar.gz", hash = "sha256:88228eee5fc21b62a1b5fe773ca15e67778cb07dc8363adcb4a8827b52d81483", size = 296359, upload-time = "2025-11-06T00:13:36.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/63/b19553b658a1692443c62bd07e5868adaa0ad746a0751ba62c59568cd45b/google_auth-2.40.3-py2.py3-none-any.whl", hash = "sha256:1370d4593e86213563547f97a92752fc658456fe4514c809544f330fed45a7ca", size = 216137, upload-time = "2025-06-04T18:04:55.573Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d1/385110a9ae86d91cc14c5282c61fe9f4dc41c0b9f7d423c6ad77038c4448/google_auth-2.43.0-py2.py3-none-any.whl", hash = "sha256:af628ba6fa493f75c7e9dbe9373d148ca9f4399b5ea29976519e0a3848eddd16", size = 223114, upload-time = "2025-11-06T00:13:35.209Z" },
 ]
 
 [[package]]
@@ -2113,39 +2113,15 @@ wheels = [
 
 [[package]]
 name = "mcpd"
-source = { editable = "../../" }
+version = "0.0.2"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "cachetools" },
     { name = "requests" },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "requests", specifier = ">=2.32.4" }]
-
-[package.metadata.requires-dev]
-all = [
-    { name = "debugpy", specifier = ">=1.8.14" },
-    { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "ruff", specifier = ">=0.11.13" },
-    { name = "setuptools", specifier = ">=80.9.0" },
-    { name = "setuptools-scm", extras = ["toml"], specifier = ">=8.3.1" },
-]
-dev = [
-    { name = "debugpy", specifier = ">=1.8.14" },
-    { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "ruff", specifier = ">=0.11.13" },
-    { name = "setuptools", specifier = ">=80.9.0" },
-    { name = "setuptools-scm", extras = ["toml"], specifier = ">=8.3.1" },
-]
-lint = [
-    { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "ruff", specifier = ">=0.11.13" },
-]
-tests = [
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "setuptools", specifier = ">=80.9.0" },
-    { name = "setuptools-scm", extras = ["toml"], specifier = ">=8.3.1" },
+sdist = { url = "https://files.pythonhosted.org/packages/77/68/07add04e4a70dd7be16fa47e3e34f3d9fc90c2cf0f6f1cd35257adcb7ef3/mcpd-0.0.2.tar.gz", hash = "sha256:9e2bfc685e237d9e1ca6c4bcca22bd083b50a65280e7f5ec21d6f45059bb28b1", size = 423944, upload-time = "2025-09-18T15:07:23.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/23b998812803c47bf8b63adbda75f31b76c2c236a2d75121c295023e4732/mcpd-0.0.2-py3-none-any.whl", hash = "sha256:01192e1276d2a03df41a2952f2a9f3b45828dafdbcf46e68f57886140bae68c3", size = 28677, upload-time = "2025-09-18T15:07:21.047Z" },
 ]
 
 [[package]]

--- a/examples/manual/.mcpd.toml
+++ b/examples/manual/.mcpd.toml
@@ -1,4 +1,4 @@
 [[servers]]
   name = "time"
-  package = "uvx::mcp-server-time@latest"
+  package = "uvx::mcp-server-time@2025.9.25"
   tools = ["get_current_time", "convert_time"]

--- a/examples/manual/README.md
+++ b/examples/manual/README.md
@@ -6,7 +6,7 @@ application code to explicitly call tools on those MCP servers.
 ## Requirements
 
 * [uv](https://docs.astral.sh/uv/getting-started/installation/)
-* [mcpd](https://github.com/mozilla-ai/mcpd-cli) built (`make build`) and installed (`sudo make install`)
+* [mcpd](https://mozilla-ai.github.io/mcpd/installation/) installed
 * `OPENAI_API_KEY` exported - this will be used by [any-agent](https://github.com/mozilla-ai/any-agent)
 
 ## Starting `mcpd`

--- a/examples/manual/pyproject.toml
+++ b/examples/manual/pyproject.toml
@@ -7,7 +7,7 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.11"
 dependencies = [
     "requests>=2.32.4",
-    "mcpd>=0.0.1",
+    "mcpd>=0.0.2",
 ]
 
 [dependency-groups]

--- a/examples/manual/uv.lock
+++ b/examples/manual/uv.lock
@@ -1,11 +1,20 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
     "python_full_version >= '3.12.4' and python_full_version < '3.13'",
     "python_full_version >= '3.12' and python_full_version < '3.12.4'",
     "python_full_version < '3.12'",
+]
+
+[[package]]
+name = "cachetools"
+version = "6.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/44/ca1675be2a83aeee1886ab745b28cda92093066590233cc501890eb8417a/cachetools-6.2.2.tar.gz", hash = "sha256:8e6d266b25e539df852251cfd6f990b4bc3a141db73b939058d809ebd2590fc6", size = 31571, upload-time = "2025-11-13T17:42:51.465Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/46/eb6eca305c77a4489affe1c5d8f4cae82f285d9addd8de4ec084a7184221/cachetools-6.2.2-py3-none-any.whl", hash = "sha256:6c09c98183bf58560c97b2abfcedcbaf6a896a490f534b031b661d3723b45ace", size = 11503, upload-time = "2025-11-13T17:42:50.232Z" },
 ]
 
 [[package]]
@@ -145,7 +154,7 @@ tests = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mcpd", editable = "../../" },
+    { name = "mcpd", specifier = ">=0.0.2" },
     { name = "requests", specifier = ">=2.32.4" },
 ]
 
@@ -206,39 +215,15 @@ wheels = [
 
 [[package]]
 name = "mcpd"
-source = { editable = "../../" }
+version = "0.0.2"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "cachetools" },
     { name = "requests" },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "requests", specifier = ">=2.32.4" }]
-
-[package.metadata.requires-dev]
-all = [
-    { name = "debugpy", specifier = ">=1.8.14" },
-    { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "ruff", specifier = ">=0.11.13" },
-    { name = "setuptools", specifier = ">=80.9.0" },
-    { name = "setuptools-scm", extras = ["toml"], specifier = ">=8.3.1" },
-]
-dev = [
-    { name = "debugpy", specifier = ">=1.8.14" },
-    { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "ruff", specifier = ">=0.11.13" },
-    { name = "setuptools", specifier = ">=80.9.0" },
-    { name = "setuptools-scm", extras = ["toml"], specifier = ">=8.3.1" },
-]
-lint = [
-    { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "ruff", specifier = ">=0.11.13" },
-]
-tests = [
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "setuptools", specifier = ">=80.9.0" },
-    { name = "setuptools-scm", extras = ["toml"], specifier = ">=8.3.1" },
+sdist = { url = "https://files.pythonhosted.org/packages/77/68/07add04e4a70dd7be16fa47e3e34f3d9fc90c2cf0f6f1cd35257adcb7ef3/mcpd-0.0.2.tar.gz", hash = "sha256:9e2bfc685e237d9e1ca6c4bcca22bd083b50a65280e7f5ec21d6f45059bb28b1", size = 423944, upload-time = "2025-09-18T15:07:23.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/23b998812803c47bf8b63adbda75f31b76c2c236a2d75121c295023e4732/mcpd-0.0.2-py3-none-any.whl", hash = "sha256:01192e1276d2a03df41a2952f2a9f3b45828dafdbcf46e68f57886140bae68c3", size = 28677, upload-time = "2025-09-18T15:07:21.047Z" },
 ]
 
 [[package]]

--- a/examples/pydantic-ai/.mcpd.toml
+++ b/examples/pydantic-ai/.mcpd.toml
@@ -1,4 +1,4 @@
 [[servers]]
   name = "time"
-  package = "uvx::mcp-server-time@latest"
+  package = "uvx::mcp-server-time@2025.9.25"
   tools = ["get_current_time", "convert_time"]

--- a/examples/pydantic-ai/README.md
+++ b/examples/pydantic-ai/README.md
@@ -6,7 +6,7 @@ application code to call tools on those MCP servers.
 ## Requirements
 
 * [uv](https://docs.astral.sh/uv/getting-started/installation/)
-* [mcpd](https://github.com/mozilla-ai/mcpd-cli) built (`make build`) and installed (`sudo make install`)
+* [mcpd](https://mozilla-ai.github.io/mcpd/installation/) installed
 * `OPENAI_API_KEY` exported - this will be used by [any-agent](https://github.com/mozilla-ai/any-agent)
 
 ## Starting `mcpd`

--- a/examples/pydantic-ai/pyproject.toml
+++ b/examples/pydantic-ai/pyproject.toml
@@ -7,7 +7,7 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.11"
 dependencies = [
     "requests>=2.32.4",
-    "mcpd>=0.0.1",
+    "mcpd>=0.0.2",
     "pydantic-ai>=0.3.7",
 ]
 

--- a/examples/pydantic-ai/uv.lock
+++ b/examples/pydantic-ai/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -187,11 +187,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "5.5.2"
+version = "6.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/44/ca1675be2a83aeee1886ab745b28cda92093066590233cc501890eb8417a/cachetools-6.2.2.tar.gz", hash = "sha256:8e6d266b25e539df852251cfd6f990b4bc3a141db73b939058d809ebd2590fc6", size = 31571, upload-time = "2025-11-13T17:42:51.465Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/46/eb6eca305c77a4489affe1c5d8f4cae82f285d9addd8de4ec084a7184221/cachetools-6.2.2-py3-none-any.whl", hash = "sha256:6c09c98183bf58560c97b2abfcedcbaf6a896a490f534b031b661d3723b45ace", size = 11503, upload-time = "2025-11-13T17:42:50.232Z" },
 ]
 
 [[package]]
@@ -382,7 +382,7 @@ tests = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mcpd", editable = "../../" },
+    { name = "mcpd", specifier = ">=0.0.2" },
     { name = "pydantic-ai", specifier = ">=0.3.7" },
     { name = "requests", specifier = ">=2.32.4" },
 ]
@@ -534,16 +534,16 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.40.3"
+version = "2.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "pyasn1-modules" },
     { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/9b/e92ef23b84fa10a64ce4831390b7a4c2e53c0132568d99d4ae61d04c8855/google_auth-2.40.3.tar.gz", hash = "sha256:500c3a29adedeb36ea9cf24b8d10858e152f2412e3ca37829b3fa18e33d63b77", size = 281029, upload-time = "2025-06-04T18:04:57.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/ef/66d14cf0e01b08d2d51ffc3c20410c4e134a1548fc246a6081eae585a4fe/google_auth-2.43.0.tar.gz", hash = "sha256:88228eee5fc21b62a1b5fe773ca15e67778cb07dc8363adcb4a8827b52d81483", size = 296359, upload-time = "2025-11-06T00:13:36.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/63/b19553b658a1692443c62bd07e5868adaa0ad746a0751ba62c59568cd45b/google_auth-2.40.3-py2.py3-none-any.whl", hash = "sha256:1370d4593e86213563547f97a92752fc658456fe4514c809544f330fed45a7ca", size = 216137, upload-time = "2025-06-04T18:04:55.573Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d1/385110a9ae86d91cc14c5282c61fe9f4dc41c0b9f7d423c6ad77038c4448/google_auth-2.43.0-py2.py3-none-any.whl", hash = "sha256:af628ba6fa493f75c7e9dbe9373d148ca9f4399b5ea29976519e0a3848eddd16", size = 223114, upload-time = "2025-11-06T00:13:35.209Z" },
 ]
 
 [[package]]
@@ -858,39 +858,15 @@ wheels = [
 
 [[package]]
 name = "mcpd"
-source = { editable = "../../" }
+version = "0.0.2"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "cachetools" },
     { name = "requests" },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "requests", specifier = ">=2.32.4" }]
-
-[package.metadata.requires-dev]
-all = [
-    { name = "debugpy", specifier = ">=1.8.14" },
-    { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "ruff", specifier = ">=0.11.13" },
-    { name = "setuptools", specifier = ">=80.9.0" },
-    { name = "setuptools-scm", extras = ["toml"], specifier = ">=8.3.1" },
-]
-dev = [
-    { name = "debugpy", specifier = ">=1.8.14" },
-    { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "ruff", specifier = ">=0.11.13" },
-    { name = "setuptools", specifier = ">=80.9.0" },
-    { name = "setuptools-scm", extras = ["toml"], specifier = ">=8.3.1" },
-]
-lint = [
-    { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "ruff", specifier = ">=0.11.13" },
-]
-tests = [
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "setuptools", specifier = ">=80.9.0" },
-    { name = "setuptools-scm", extras = ["toml"], specifier = ">=8.3.1" },
+sdist = { url = "https://files.pythonhosted.org/packages/77/68/07add04e4a70dd7be16fa47e3e34f3d9fc90c2cf0f6f1cd35257adcb7ef3/mcpd-0.0.2.tar.gz", hash = "sha256:9e2bfc685e237d9e1ca6c4bcca22bd083b50a65280e7f5ec21d6f45059bb28b1", size = 423944, upload-time = "2025-09-18T15:07:23.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/23b998812803c47bf8b63adbda75f31b76c2c236a2d75121c295023e4732/mcpd-0.0.2-py3-none-any.whl", hash = "sha256:01192e1276d2a03df41a2952f2a9f3b45828dafdbcf46e68f57886140bae68c3", size = 28677, upload-time = "2025-09-18T15:07:21.047Z" },
 ]
 
 [[package]]

--- a/examples/readme_maker/README.md
+++ b/examples/readme_maker/README.md
@@ -21,7 +21,7 @@ source venv/bin/activate
 uv sync --group all
 ```
 
-### Step 3: Initialize a new MCPD project and add the GitHub MCP server
+### Step 3: Initialize a new mcpd project and add the GitHub MCP server
 ```bash
 mcpd init
 mcpd add github
@@ -33,7 +33,7 @@ export <PROVIDER>_API_KEY=your_<provider>_api_key # Required for the Agent, the 
 mcpd config env set github GITHUB_PERSONAL_ACCESS_TOKEN=your_github_token # Required by the GitHub MCP server
 ```
 
-### Step 5: Start the MCPD server
+### Step 5: Start the mcpd server
 ```bash
 mcpd daemon
 ```

--- a/examples/readme_maker/pyproject.toml
+++ b/examples/readme_maker/pyproject.toml
@@ -7,7 +7,7 @@ license = {text = "Apache-2.0"}
 requires-python = ">=3.11"
 dependencies = [
     "requests>=2.32.4",
-    "mcpd>=0.0.1",
+    "mcpd>=0.0.2",
     "pydantic-ai>=0.3.7",
 ]
 

--- a/examples/readme_maker/readme_maker.py
+++ b/examples/readme_maker/readme_maker.py
@@ -8,7 +8,7 @@ load_dotenv()  # Load the API key for the agent (using Mistral in this case)
 
 agent_model = "mistral:mistral-large-2411"
 
-# Connect to the MCPD server to enable the agent access the tools running on it.
+# Connect to the mcpd server to enable the agent access the tools running on it.
 client = McpdClient(api_endpoint="http://localhost:8090")
 
 agent = Agent(

--- a/examples/readme_maker/uv.lock
+++ b/examples/readme_maker/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -96,11 +96,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "5.5.2"
+version = "6.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/81/3747dad6b14fa2cf53fcf10548cf5aea6913e96fab41a3c198676f8948a5/cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4", size = 28380, upload-time = "2025-02-20T21:01:19.524Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/44/ca1675be2a83aeee1886ab745b28cda92093066590233cc501890eb8417a/cachetools-6.2.2.tar.gz", hash = "sha256:8e6d266b25e539df852251cfd6f990b4bc3a141db73b939058d809ebd2590fc6", size = 31571, upload-time = "2025-11-13T17:42:51.465Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/72/76/20fa66124dbe6be5cafeb312ece67de6b61dd91a0247d1ea13db4ebb33c2/cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a", size = 10080, upload-time = "2025-02-20T21:01:16.647Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/46/eb6eca305c77a4489affe1c5d8f4cae82f285d9addd8de4ec084a7184221/cachetools-6.2.2-py3-none-any.whl", hash = "sha256:6c09c98183bf58560c97b2abfcedcbaf6a896a490f534b031b661d3723b45ace", size = 11503, upload-time = "2025-11-13T17:42:50.232Z" },
 ]
 
 [[package]]
@@ -291,7 +291,7 @@ tests = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mcpd", editable = "../../" },
+    { name = "mcpd", specifier = ">=0.0.2" },
     { name = "pydantic-ai", specifier = ">=0.3.7" },
     { name = "requests", specifier = ">=2.32.4" },
 ]
@@ -380,16 +380,16 @@ wheels = [
 
 [[package]]
 name = "google-auth"
-version = "2.40.3"
+version = "2.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
     { name = "pyasn1-modules" },
     { name = "rsa" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/9b/e92ef23b84fa10a64ce4831390b7a4c2e53c0132568d99d4ae61d04c8855/google_auth-2.40.3.tar.gz", hash = "sha256:500c3a29adedeb36ea9cf24b8d10858e152f2412e3ca37829b3fa18e33d63b77", size = 281029, upload-time = "2025-06-04T18:04:57.577Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/ef/66d14cf0e01b08d2d51ffc3c20410c4e134a1548fc246a6081eae585a4fe/google_auth-2.43.0.tar.gz", hash = "sha256:88228eee5fc21b62a1b5fe773ca15e67778cb07dc8363adcb4a8827b52d81483", size = 296359, upload-time = "2025-11-06T00:13:36.587Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/17/63/b19553b658a1692443c62bd07e5868adaa0ad746a0751ba62c59568cd45b/google_auth-2.40.3-py2.py3-none-any.whl", hash = "sha256:1370d4593e86213563547f97a92752fc658456fe4514c809544f330fed45a7ca", size = 216137, upload-time = "2025-06-04T18:04:55.573Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/d1/385110a9ae86d91cc14c5282c61fe9f4dc41c0b9f7d423c6ad77038c4448/google_auth-2.43.0-py2.py3-none-any.whl", hash = "sha256:af628ba6fa493f75c7e9dbe9373d148ca9f4399b5ea29976519e0a3848eddd16", size = 223114, upload-time = "2025-11-06T00:13:35.209Z" },
 ]
 
 [[package]]
@@ -699,39 +699,15 @@ wheels = [
 
 [[package]]
 name = "mcpd"
-source = { editable = "../../" }
+version = "0.0.2"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "cachetools" },
     { name = "requests" },
 ]
-
-[package.metadata]
-requires-dist = [{ name = "requests", specifier = ">=2.32.4" }]
-
-[package.metadata.requires-dev]
-all = [
-    { name = "debugpy", specifier = ">=1.8.14" },
-    { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "ruff", specifier = ">=0.11.13" },
-    { name = "setuptools", specifier = ">=80.9.0" },
-    { name = "setuptools-scm", extras = ["toml"], specifier = ">=8.3.1" },
-]
-dev = [
-    { name = "debugpy", specifier = ">=1.8.14" },
-    { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "ruff", specifier = ">=0.11.13" },
-    { name = "setuptools", specifier = ">=80.9.0" },
-    { name = "setuptools-scm", extras = ["toml"], specifier = ">=8.3.1" },
-]
-lint = [
-    { name = "pre-commit", specifier = ">=4.2.0" },
-    { name = "ruff", specifier = ">=0.11.13" },
-]
-tests = [
-    { name = "pytest", specifier = ">=8.3.5" },
-    { name = "setuptools", specifier = ">=80.9.0" },
-    { name = "setuptools-scm", extras = ["toml"], specifier = ">=8.3.1" },
+sdist = { url = "https://files.pythonhosted.org/packages/77/68/07add04e4a70dd7be16fa47e3e34f3d9fc90c2cf0f6f1cd35257adcb7ef3/mcpd-0.0.2.tar.gz", hash = "sha256:9e2bfc685e237d9e1ca6c4bcca22bd083b50a65280e7f5ec21d6f45059bb28b1", size = 423944, upload-time = "2025-09-18T15:07:23.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/23b998812803c47bf8b63adbda75f31b76c2c236a2d75121c295023e4732/mcpd-0.0.2-py3-none-any.whl", hash = "sha256:01192e1276d2a03df41a2952f2a9f3b45828dafdbcf46e68f57886140bae68c3", size = 28677, upload-time = "2025-09-18T15:07:21.047Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
* Use time MCP server version 2025.9.25
* Bump mcpd SDK to version 0.0.2
* Update READMEs with mcpd installation docs
* Fix casing of 'mcpd' (not MCPD)
* Update lock files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped mcpd dependency minimum to >=0.0.2 and updated time server package to 2025.9.25 across example projects.

* **Documentation**
  * Simplified installation instructions with updated reference links.
  * Standardised naming to use lowercase "mcpd" consistently in READMEs and comments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->