### PR TITLE
Add PipelineError for mcpd plugin pipeline failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,8 +280,54 @@ client = McpdClient(
 
 ## Error Handling
 
-All SDK-level errors, including HTTP and connection errors, will raise a `McpdError` exception.
-The original exception is chained for full context.
+All SDK-level errors raise exceptions that inherit from `McpdError`. The original exception is chained via `__cause__` for full context.
+
+### Exception Types
+
+| Exception              | Description                             |
+|------------------------|-----------------------------------------|
+| `McpdError`            | Base exception for all SDK errors       |
+| `ConnectionError`      | Unable to connect to `mcpd` daemon      |
+| `AuthenticationError`  | Authentication failed (invalid API key) |
+| `ServerNotFoundError`  | Specified server doesn't exist          |
+| `ServerUnhealthyError` | Server exists but is not healthy        |
+| `ToolNotFoundError`    | Specified tool doesn't exist on server  |
+| `ToolExecutionError`   | Tool execution failed                   |
+| `ValidationError`      | Input validation failed                 |
+| `TimeoutError`         | Operation timed out                     |
+| `PipelineError`        | Required pipeline processing failed     |
+
+### Example
+
+```python
+from mcpd import (
+    McpdClient,
+    McpdError,
+    PipelineError,
+    PIPELINE_FLOW_REQUEST,
+    PIPELINE_FLOW_RESPONSE,
+    ServerNotFoundError,
+    ToolExecutionError,
+)
+
+client = McpdClient(api_endpoint="http://localhost:8090")
+
+try:
+    result = client.call.time.get_current_time()
+except PipelineError as e:
+    # A required plugin failed during request or response processing.
+    if e.pipeline_flow == PIPELINE_FLOW_RESPONSE:
+        print("Tool was called but results cannot be delivered")
+    elif e.pipeline_flow == PIPELINE_FLOW_REQUEST:
+        print("Request was rejected by pipeline")
+except ServerNotFoundError as e:
+    print(f"Server '{e.server_name}' not found")
+except ToolExecutionError as e:
+    print(f"Tool '{e.tool_name}' failed: {e}")
+except McpdError as e:
+    # Catch-all for any other SDK errors.
+    print(f"Operation failed: {e}")
+```
 
 
 ## License

--- a/src/mcpd/__init__.py
+++ b/src/mcpd/__init__.py
@@ -14,9 +14,12 @@ This package provides:
 
 from ._logger import Logger, LogLevel
 from .exceptions import (
+    PIPELINE_FLOW_REQUEST,
+    PIPELINE_FLOW_RESPONSE,
     AuthenticationError,
     ConnectionError,
     McpdError,
+    PipelineError,
     ServerNotFoundError,
     ServerUnhealthyError,
     TimeoutError,
@@ -34,6 +37,9 @@ __all__ = [
     "McpdError",
     "AuthenticationError",
     "ConnectionError",
+    "PipelineError",
+    "PIPELINE_FLOW_REQUEST",
+    "PIPELINE_FLOW_RESPONSE",
     "ServerNotFoundError",
     "ServerUnhealthyError",
     "TimeoutError",

--- a/src/mcpd/exceptions.py
+++ b/src/mcpd/exceptions.py
@@ -361,10 +361,10 @@ class PipelineError(McpdError):
     def __init__(
         self,
         message: str,
-        server_name: str = None,
-        operation: str = None,
-        pipeline_flow: str = None,
-    ):
+        server_name: str | None = None,
+        operation: str | None = None,
+        pipeline_flow: str | None = None,
+    ) -> None:
         """Initialize PipelineError.
 
         Args:

--- a/src/mcpd/exceptions.py
+++ b/src/mcpd/exceptions.py
@@ -2,7 +2,27 @@
 
 This module provides a structured exception hierarchy to help users handle
 different error scenarios appropriately.
+
+Constants:
+    PIPELINE_FLOW_REQUEST: Flow constant indicating a request pipeline failure.
+        The request was rejected before reaching the upstream server.
+    PIPELINE_FLOW_RESPONSE: Flow constant indicating a response pipeline failure.
+        The upstream request was processed but results cannot be returned.
 """
+
+#: Flow constant for request pipeline failures.
+#: The request was rejected before reaching the upstream server.
+PIPELINE_FLOW_REQUEST: str = "request"
+
+#: Flow constant for response pipeline failures.
+#: The upstream request was processed but results cannot be returned.
+PIPELINE_FLOW_RESPONSE: str = "response"
+
+# Internal mapping from mcpd error type header values to flow constants.
+_PIPELINE_ERROR_FLOWS: dict[str, str] = {
+    "request-pipeline-failure": PIPELINE_FLOW_REQUEST,
+    "response-pipeline-failure": PIPELINE_FLOW_RESPONSE,
+}
 
 
 class McpdError(Exception):
@@ -303,3 +323,57 @@ class TimeoutError(McpdError):
         super().__init__(message)
         self.operation = operation
         self.timeout = timeout
+
+
+class PipelineError(McpdError):
+    """Raised when required pipeline processing fails.
+
+    This indicates that a required plugin failed during request or response
+    processing. This typically indicates a problem with a plugin or an external
+    system that a plugin depends on (e.g., audit service, authentication provider).
+
+    Pipeline Flow Distinction:
+    - **response-pipeline-failure**: The upstream request was processed (the tool
+      was called), but results cannot be returned due to a required response
+      processing step failure. Note: This does not indicate whether the tool
+      itself succeeded or failed - only that the response cannot be delivered.
+
+    - **request-pipeline-failure**: The request was rejected before reaching the
+      upstream server due to a required request processing step failure (such as
+      authentication, authorization, validation, or rate limiting plugin failure).
+
+    Attributes:
+        server_name: The server name (when called through tool execution).
+        operation: The operation (e.g., "time.get_current_time").
+        pipeline_flow: Which pipeline flow failed ("request" or "response").
+
+    Example:
+        >>> try:
+        >>>     result = client.call.time.get_current_time()
+        >>> except PipelineError as e:
+        >>>     print(f"Pipeline {e.pipeline_flow} failure: {e}")
+        >>>     if e.pipeline_flow == "response":
+        >>>         print("Tool was called but results cannot be delivered")
+        >>>     else:
+        >>>         print("Request was rejected by pipeline")
+    """
+
+    def __init__(
+        self,
+        message: str,
+        server_name: str = None,
+        operation: str = None,
+        pipeline_flow: str = None,
+    ):
+        """Initialize PipelineError.
+
+        Args:
+            message: The error message.
+            server_name: The name of the server (when called through tool execution).
+            operation: The operation (e.g., "time.get_current_time").
+            pipeline_flow: Which pipeline flow failed ("request" or "response").
+        """
+        super().__init__(message)
+        self.server_name = server_name
+        self.operation = operation
+        self.pipeline_flow = pipeline_flow

--- a/src/mcpd/mcpd_client.py
+++ b/src/mcpd/mcpd_client.py
@@ -13,7 +13,7 @@ import threading
 from collections.abc import Callable
 from enum import Enum
 from functools import wraps
-from typing import Any, ParamSpec, Protocol, TypeVar
+from typing import Any, NoReturn, ParamSpec, Protocol, TypeVar
 
 import requests
 from cachetools import TTLCache, cached
@@ -21,9 +21,11 @@ from cachetools import TTLCache, cached
 from ._logger import Logger, create_logger
 from .dynamic_caller import DynamicCaller
 from .exceptions import (
+    _PIPELINE_ERROR_FLOWS,
     AuthenticationError,
     ConnectionError,
     McpdError,
+    PipelineError,
     ServerNotFoundError,
     ServerUnhealthyError,
     TimeoutError,
@@ -33,6 +35,54 @@ from .function_builder import TOOL_SEPARATOR, FunctionBuilder
 
 P = ParamSpec("P")
 R = TypeVar("R")
+
+# Header name for mcpd pipeline error type (internal).
+_MCPD_ERROR_TYPE_HEADER = "Mcpd-Error-Type"
+
+
+def _raise_for_http_error(
+    error: requests.exceptions.HTTPError,
+    server_name: str,
+    tool_name: str,
+) -> NoReturn:
+    """Raise appropriate McpdError for HTTP error responses."""
+    status = error.response.status_code
+
+    if status == 401:
+        raise AuthenticationError(
+            f"Authentication failed when calling '{tool_name}' on '{server_name}': {error}"
+        ) from error
+
+    if status == 404:
+        raise ServerNotFoundError(f"Server '{server_name}' not found", server_name=server_name) from error
+
+    # Check for pipeline failure (500 with Mcpd-Error-Type header).
+    if status == 500:
+        error_type = error.response.headers.get(_MCPD_ERROR_TYPE_HEADER, "").lower()
+        flow = _PIPELINE_ERROR_FLOWS.get(error_type)
+        if flow:
+            message = error.response.text or "Pipeline failure"
+            raise PipelineError(
+                message=message,
+                server_name=server_name,
+                operation=f"{server_name}.{tool_name}",
+                pipeline_flow=flow,
+            ) from error
+
+    # 5xx server errors.
+    if status >= 500:
+        raise ToolExecutionError(
+            f"Server error when executing '{tool_name}' on '{server_name}': {error}",
+            server_name=server_name,
+            tool_name=tool_name,
+        ) from error
+
+    # Other HTTP errors (4xx).
+    raise ToolExecutionError(
+        f"Error calling tool '{tool_name}' on server '{server_name}': {error}",
+        server_name=server_name,
+        tool_name=tool_name,
+    ) from error
 
 
 class _AgentFunction(Protocol):
@@ -216,24 +266,7 @@ class McpdClient:
                 "Tool execution timed out after 30 seconds", operation=f"{server_name}.{tool_name}", timeout=30
             ) from e
         except requests.exceptions.HTTPError as e:
-            if e.response.status_code == 401:
-                raise AuthenticationError(
-                    f"Authentication failed when calling '{tool_name}' on '{server_name}': {e}"
-                ) from e
-            elif e.response.status_code == 404:
-                raise ServerNotFoundError(f"Server '{server_name}' not found", server_name=server_name) from e
-            elif e.response.status_code >= 500:
-                raise ToolExecutionError(
-                    f"Server error when executing '{tool_name}' on '{server_name}': {e}",
-                    server_name=server_name,
-                    tool_name=tool_name,
-                ) from e
-            else:
-                raise ToolExecutionError(
-                    f"Error calling tool '{tool_name}' on server '{server_name}': {e}",
-                    server_name=server_name,
-                    tool_name=tool_name,
-                ) from e
+            _raise_for_http_error(e, server_name, tool_name)
         except requests.exceptions.RequestException as e:
             raise McpdError(f"Error calling tool '{tool_name}' on server '{server_name}': {e}") from e
 

--- a/src/mcpd/mcpd_client.py
+++ b/src/mcpd/mcpd_client.py
@@ -58,7 +58,7 @@ def _raise_for_http_error(
 
     # Check for pipeline failure (500 with Mcpd-Error-Type header).
     if status == 500:
-        error_type = error.response.headers.get(_MCPD_ERROR_TYPE_HEADER, "").lower()
+        error_type = (error.response.headers.get(_MCPD_ERROR_TYPE_HEADER) or "").lower()
         flow = _PIPELINE_ERROR_FLOWS.get(error_type)
         if flow:
             message = error.response.text or "Pipeline failure"

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -5,9 +5,13 @@ import requests
 
 from mcpd import McpdClient
 from mcpd.exceptions import (
+    _PIPELINE_ERROR_FLOWS,
+    PIPELINE_FLOW_REQUEST,
+    PIPELINE_FLOW_RESPONSE,
     AuthenticationError,
     ConnectionError,
     McpdError,
+    PipelineError,
     ServerNotFoundError,
     ServerUnhealthyError,
     TimeoutError,
@@ -126,6 +130,7 @@ class TestExceptionHierarchy:
         """Verify exception hierarchy."""
         assert issubclass(ConnectionError, McpdError)
         assert issubclass(AuthenticationError, McpdError)
+        assert issubclass(PipelineError, McpdError)
         assert issubclass(ServerNotFoundError, McpdError)
         assert issubclass(ServerUnhealthyError, McpdError)
         assert issubclass(ToolNotFoundError, McpdError)
@@ -138,6 +143,7 @@ class TestExceptionHierarchy:
         exceptions = [
             ConnectionError("test"),
             AuthenticationError("test"),
+            PipelineError("test", server_name="server1", operation="server1.tool1", pipeline_flow="request"),
             ServerNotFoundError("test", server_name="server1"),
             ServerUnhealthyError("test", server_name="server1", health_status="timeout"),
             ToolNotFoundError("test", server_name="server1", tool_name="tool1"),
@@ -453,3 +459,152 @@ class TestValidationError:
         """Test ValidationError with no specific errors."""
         exc = ValidationError("Validation failed")
         assert exc.validation_errors == []
+
+
+class TestPipelineError:
+    """Test PipelineError is raised appropriately."""
+
+    def test_pipeline_error_attributes(self):
+        """Test PipelineError stores all attributes."""
+        exc = PipelineError(
+            "Pipeline failure",
+            server_name="test_server",
+            operation="test_server.test_tool",
+            pipeline_flow=PIPELINE_FLOW_REQUEST,
+        )
+        assert exc.server_name == "test_server"
+        assert exc.operation == "test_server.test_tool"
+        assert exc.pipeline_flow == PIPELINE_FLOW_REQUEST
+        assert "Pipeline failure" in str(exc)
+
+    def test_pipeline_error_response_flow(self):
+        """Test PipelineError with response flow."""
+        exc = PipelineError(
+            "Response pipeline failed",
+            server_name="time",
+            operation="time.get_current_time",
+            pipeline_flow=PIPELINE_FLOW_RESPONSE,
+        )
+        assert exc.pipeline_flow == PIPELINE_FLOW_RESPONSE
+
+    def test_pipeline_error_minimal(self):
+        """Test PipelineError with only message."""
+        exc = PipelineError("Minimal error")
+        assert exc.server_name is None
+        assert exc.operation is None
+        assert exc.pipeline_flow is None
+
+    def test_pipeline_flow_constants(self):
+        """Test pipeline flow constants have expected values."""
+        assert PIPELINE_FLOW_REQUEST == "request"
+        assert PIPELINE_FLOW_RESPONSE == "response"
+
+    def test_pipeline_error_flows_mapping(self):
+        """Test _PIPELINE_ERROR_FLOWS mapping from header values to flow constants."""
+        assert _PIPELINE_ERROR_FLOWS["request-pipeline-failure"] == PIPELINE_FLOW_REQUEST
+        assert _PIPELINE_ERROR_FLOWS["response-pipeline-failure"] == PIPELINE_FLOW_RESPONSE
+
+    @patch("requests.Session")
+    def test_pipeline_error_on_request_failure(self, mock_session_class):
+        """Test PipelineError raised on 500 with request-pipeline-failure header."""
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.headers = {"Mcpd-Error-Type": "request-pipeline-failure"}
+        mock_response.text = "Request pipeline processing failed"
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(response=mock_response)
+        mock_session.post.return_value = mock_response
+
+        client = McpdClient(api_endpoint="http://localhost:8090")
+
+        with pytest.raises(PipelineError) as exc_info:
+            client._perform_call("test_server", "test_tool", {"param": "value"})
+
+        assert exc_info.value.pipeline_flow == PIPELINE_FLOW_REQUEST
+        assert exc_info.value.server_name == "test_server"
+        assert exc_info.value.operation == "test_server.test_tool"
+        assert "Request pipeline processing failed" in str(exc_info.value)
+
+    @patch("requests.Session")
+    def test_pipeline_error_on_response_failure(self, mock_session_class):
+        """Test PipelineError raised on 500 with response-pipeline-failure header."""
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.headers = {"Mcpd-Error-Type": "response-pipeline-failure"}
+        mock_response.text = "Response pipeline processing failed"
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(response=mock_response)
+        mock_session.post.return_value = mock_response
+
+        client = McpdClient(api_endpoint="http://localhost:8090")
+
+        with pytest.raises(PipelineError) as exc_info:
+            client._perform_call("test_server", "test_tool", {"param": "value"})
+
+        assert exc_info.value.pipeline_flow == PIPELINE_FLOW_RESPONSE
+        assert exc_info.value.server_name == "test_server"
+        assert exc_info.value.operation == "test_server.test_tool"
+        assert "Response pipeline processing failed" in str(exc_info.value)
+
+    @patch("requests.Session")
+    def test_500_without_header_is_tool_execution_error(self, mock_session_class):
+        """Test that 500 without Mcpd-Error-Type header raises ToolExecutionError."""
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.headers = {}
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(response=mock_response)
+        mock_session.post.return_value = mock_response
+
+        client = McpdClient(api_endpoint="http://localhost:8090")
+
+        with pytest.raises(ToolExecutionError) as exc_info:
+            client._perform_call("test_server", "test_tool", {"param": "value"})
+
+        assert "Server error when executing 'test_tool'" in str(exc_info.value)
+
+    @patch("requests.Session")
+    def test_pipeline_error_case_insensitive_header(self, mock_session_class):
+        """Test PipelineError handles case-insensitive header values."""
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.headers = {"Mcpd-Error-Type": "REQUEST-PIPELINE-FAILURE"}
+        mock_response.text = "Pipeline failed"
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(response=mock_response)
+        mock_session.post.return_value = mock_response
+
+        client = McpdClient(api_endpoint="http://localhost:8090")
+
+        with pytest.raises(PipelineError) as exc_info:
+            client._perform_call("test_server", "test_tool", {})
+
+        assert exc_info.value.pipeline_flow == PIPELINE_FLOW_REQUEST
+
+    @patch("requests.Session")
+    def test_pipeline_error_empty_body_uses_default_message(self, mock_session_class):
+        """Test PipelineError uses default message when response body is empty."""
+        mock_session = Mock()
+        mock_session_class.return_value = mock_session
+
+        mock_response = Mock()
+        mock_response.status_code = 500
+        mock_response.headers = {"Mcpd-Error-Type": "response-pipeline-failure"}
+        mock_response.text = ""
+        mock_response.raise_for_status.side_effect = requests.exceptions.HTTPError(response=mock_response)
+        mock_session.post.return_value = mock_response
+
+        client = McpdClient(api_endpoint="http://localhost:8090")
+
+        with pytest.raises(PipelineError) as exc_info:
+            client._perform_call("test_server", "test_tool", {})
+
+        assert "Pipeline failure" in str(exc_info.value)

--- a/tests/unit/test_mcpd_client.py
+++ b/tests/unit/test_mcpd_client.py
@@ -2,10 +2,23 @@ import math
 from unittest.mock import Mock, patch
 
 import pytest
+import requests
 from requests import Session
 from requests.exceptions import RequestException
 
-from mcpd import AuthenticationError, HealthStatus, McpdClient, McpdError, ServerNotFoundError, ServerUnhealthyError
+from mcpd import (
+    PIPELINE_FLOW_REQUEST,
+    PIPELINE_FLOW_RESPONSE,
+    AuthenticationError,
+    HealthStatus,
+    McpdClient,
+    McpdError,
+    PipelineError,
+    ServerNotFoundError,
+    ServerUnhealthyError,
+    ToolExecutionError,
+)
+from mcpd.mcpd_client import _raise_for_http_error
 
 
 class TestHealthStatus:
@@ -26,6 +39,158 @@ class TestHealthStatus:
         assert HealthStatus.is_transient(HealthStatus.UNKNOWN.value)
         assert not HealthStatus.is_transient(HealthStatus.OK.value)
         assert not HealthStatus.is_transient(HealthStatus.UNREACHABLE.value)
+
+
+class TestRaiseForHttpError:
+    """Unit tests for _raise_for_http_error helper function."""
+
+    @staticmethod
+    def _make_http_error(
+        status_code: int,
+        headers: dict | None = None,
+        text: str = "",
+    ) -> requests.exceptions.HTTPError:
+        """Create a mock HTTPError with the given status code and headers."""
+        response = Mock()
+        response.status_code = status_code
+        response.headers = headers or {}
+        response.text = text
+        error = requests.exceptions.HTTPError(response=response)
+        return error
+
+    def test_401_raises_authentication_error(self):
+        """Test that 401 status raises AuthenticationError."""
+        error = self._make_http_error(401)
+
+        with pytest.raises(AuthenticationError) as exc_info:
+            _raise_for_http_error(error, "test_server", "test_tool")
+
+        assert "Authentication failed" in str(exc_info.value)
+        assert "test_tool" in str(exc_info.value)
+        assert "test_server" in str(exc_info.value)
+
+    def test_404_raises_server_not_found_error(self):
+        """Test that 404 status raises ServerNotFoundError."""
+        error = self._make_http_error(404)
+
+        with pytest.raises(ServerNotFoundError) as exc_info:
+            _raise_for_http_error(error, "missing_server", "some_tool")
+
+        assert exc_info.value.server_name == "missing_server"
+
+    def test_500_with_request_pipeline_header_raises_pipeline_error(self):
+        """Test that 500 with request-pipeline-failure header raises PipelineError."""
+        error = self._make_http_error(
+            500,
+            headers={"Mcpd-Error-Type": "request-pipeline-failure"},
+            text="Auth plugin failed",
+        )
+
+        with pytest.raises(PipelineError) as exc_info:
+            _raise_for_http_error(error, "time", "get_current_time")
+
+        assert exc_info.value.pipeline_flow == PIPELINE_FLOW_REQUEST
+        assert exc_info.value.server_name == "time"
+        assert exc_info.value.operation == "time.get_current_time"
+        assert "Auth plugin failed" in str(exc_info.value)
+
+    def test_500_with_response_pipeline_header_raises_pipeline_error(self):
+        """Test that 500 with response-pipeline-failure header raises PipelineError."""
+        error = self._make_http_error(
+            500,
+            headers={"Mcpd-Error-Type": "response-pipeline-failure"},
+            text="Audit logging failed",
+        )
+
+        with pytest.raises(PipelineError) as exc_info:
+            _raise_for_http_error(error, "fetch", "download")
+
+        assert exc_info.value.pipeline_flow == PIPELINE_FLOW_RESPONSE
+        assert exc_info.value.server_name == "fetch"
+        assert exc_info.value.operation == "fetch.download"
+
+    def test_500_without_header_raises_tool_execution_error(self):
+        """Test that 500 without pipeline header raises ToolExecutionError."""
+        error = self._make_http_error(500)
+
+        with pytest.raises(ToolExecutionError) as exc_info:
+            _raise_for_http_error(error, "broken_server", "failing_tool")
+
+        assert "Server error" in str(exc_info.value)
+        assert exc_info.value.server_name == "broken_server"
+        assert exc_info.value.tool_name == "failing_tool"
+
+    def test_502_raises_tool_execution_error(self):
+        """Test that 502 Bad Gateway raises ToolExecutionError."""
+        error = self._make_http_error(502)
+
+        with pytest.raises(ToolExecutionError) as exc_info:
+            _raise_for_http_error(error, "proxy_server", "remote_tool")
+
+        assert "Server error" in str(exc_info.value)
+
+    def test_503_raises_tool_execution_error(self):
+        """Test that 503 Service Unavailable raises ToolExecutionError."""
+        error = self._make_http_error(503)
+
+        with pytest.raises(ToolExecutionError) as exc_info:
+            _raise_for_http_error(error, "overloaded", "busy_tool")
+
+        assert "Server error" in str(exc_info.value)
+
+    def test_400_raises_tool_execution_error(self):
+        """Test that 400 Bad Request raises ToolExecutionError with generic message."""
+        error = self._make_http_error(400)
+
+        with pytest.raises(ToolExecutionError) as exc_info:
+            _raise_for_http_error(error, "api_server", "validate_tool")
+
+        assert "Error calling tool" in str(exc_info.value)
+        assert "Server error" not in str(exc_info.value)
+
+    def test_403_raises_tool_execution_error(self):
+        """Test that 403 Forbidden raises ToolExecutionError with generic message."""
+        error = self._make_http_error(403)
+
+        with pytest.raises(ToolExecutionError) as exc_info:
+            _raise_for_http_error(error, "secure_server", "protected_tool")
+
+        assert "Error calling tool" in str(exc_info.value)
+
+    def test_pipeline_header_case_insensitive(self):
+        """Test that pipeline header value is case-insensitive."""
+        error = self._make_http_error(
+            500,
+            headers={"Mcpd-Error-Type": "REQUEST-PIPELINE-FAILURE"},
+            text="Failed",
+        )
+
+        with pytest.raises(PipelineError) as exc_info:
+            _raise_for_http_error(error, "server", "tool")
+
+        assert exc_info.value.pipeline_flow == PIPELINE_FLOW_REQUEST
+
+    def test_pipeline_error_empty_body_uses_default(self):
+        """Test that empty response body uses default message."""
+        error = self._make_http_error(
+            500,
+            headers={"Mcpd-Error-Type": "response-pipeline-failure"},
+            text="",
+        )
+
+        with pytest.raises(PipelineError) as exc_info:
+            _raise_for_http_error(error, "server", "tool")
+
+        assert "Pipeline failure" in str(exc_info.value)
+
+    def test_error_chaining_preserved(self):
+        """Test that original error is chained via __cause__."""
+        error = self._make_http_error(500)
+
+        with pytest.raises(ToolExecutionError) as exc_info:
+            _raise_for_http_error(error, "server", "tool")
+
+        assert exc_info.value.__cause__ is error
 
 
 class TestMcpdClient:


### PR DESCRIPTION
Detect pipeline failures via Mcpd-Error-Type HTTP header on 500 responses. Raises PipelineError with pipeline_flow indicating request or response failure.

- Add PipelineError class and PIPELINE_FLOW_REQUEST/RESPONSE constants
- Extract HTTP error handling into _raise_for_http_error() helper
- Add comprehensive unit tests for error handling
- Update README with error handling documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - PipelineError exception added to the public API
  - Pipeline flow constants PIPELINE_FLOW_REQUEST and PIPELINE_FLOW_RESPONSE introduced

* **Documentation**
  - Error Handling section expanded with an Exception Types table, detailed usage examples and guidance on exception chaining

* **Tests**
  - New tests covering PipelineError behaviour, flow mapping, header handling and HTTP error routing

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->